### PR TITLE
fix(job-ad): fix rendering issue by splitting mobile and desktop views

### DIFF
--- a/src/components/jobAd/JobAdDesktopView.tsx
+++ b/src/components/jobAd/JobAdDesktopView.tsx
@@ -1,0 +1,34 @@
+import { LayoutBlockVariation, LayoutColumnsElement, LayoutColumnsVariation } from "@digi/arbetsformedlingen";
+import { DigiLayoutBlock, DigiLayoutColumns, DigiTypography } from "@digi/arbetsformedlingen-react";
+import { JobAdApply } from "./JobAdApply";
+import { JobAdDate } from "./JobAdDate";
+import { JobAdDescription } from "./JobAdDescription";
+import { JobAdDetails } from "./JobAdDetails";
+import { JobAdEmployer } from "./JobAdEmployer";
+import type { IJobAdDetailed } from "../../models/IJobAd";
+
+type JobAdMDesktopViewProps = {
+	jobAd: IJobAdDetailed;
+};
+
+export const JobAdDesktopView = ({ jobAd }: JobAdMDesktopViewProps) => {
+	return (
+		<>
+			<DigiTypography style={{ wordBreak: "break-word" }}>
+				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
+					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.TWO}>
+						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
+							<JobAdDetails jobAd={jobAd} />
+							<JobAdDescription jobAd={jobAd} />
+							<JobAdDate jobAd={jobAd} />
+						</DigiLayoutBlock>
+						<DigiLayoutBlock afVariation={LayoutBlockVariation.SECONDARY} afVerticalPadding={false}>
+							<JobAdEmployer jobAd={jobAd} />
+							<JobAdApply jobAd={jobAd} />
+						</DigiLayoutBlock>
+					</DigiLayoutColumns>
+				</DigiLayoutBlock>
+			</DigiTypography>
+		</>
+	);
+};

--- a/src/components/jobAd/JobAdMobileView.tsx
+++ b/src/components/jobAd/JobAdMobileView.tsx
@@ -1,0 +1,32 @@
+import { LayoutBlockVariation, LayoutColumnsElement, LayoutColumnsVariation } from "@digi/arbetsformedlingen";
+import { DigiLayoutBlock, DigiLayoutColumns, DigiTypography } from "@digi/arbetsformedlingen-react";
+import { JobAdApply } from "./JobAdApply";
+import { JobAdDate } from "./JobAdDate";
+import { JobAdDescription } from "./JobAdDescription";
+import { JobAdDetails } from "./JobAdDetails";
+import { JobAdEmployer } from "./JobAdEmployer";
+import type { IJobAdDetailed } from "../../models/IJobAd";
+
+type JobAdMobileViewProps = {
+	jobAd: IJobAdDetailed;
+};
+
+export const JobAdMobileView = ({ jobAd }: JobAdMobileViewProps) => {
+	return (
+		<>
+			<DigiTypography style={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
+				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
+					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.ONE}>
+						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
+							<JobAdDetails jobAd={jobAd} />
+							<JobAdDescription jobAd={jobAd} />
+							<JobAdEmployer jobAd={jobAd} />
+							<JobAdApply jobAd={jobAd} />
+							<JobAdDate jobAd={jobAd} />
+						</DigiLayoutBlock>
+					</DigiLayoutColumns>
+				</DigiLayoutBlock>
+			</DigiTypography>
+		</>
+	);
+};

--- a/src/pages/JobAd.tsx
+++ b/src/pages/JobAd.tsx
@@ -2,15 +2,10 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { getJobAdById } from "../services/jobAdsService";
 import type { IJobAdDetailed } from "../models/IJobAd";
-import { DigiLayoutBlock, DigiLayoutColumns, DigiTypography } from "@digi/arbetsformedlingen-react";
-import { LayoutBlockVariation, LayoutColumnsElement, LayoutColumnsVariation } from "@digi/arbetsformedlingen";
-import { JobAdDescription } from "../components/jobAd/JobAdDescription";
-import { JobAdApply } from "../components/jobAd/JobAdApply";
-import { JobAdDetails } from "../components/jobAd/JobAdDetails";
 import { LoadingSpinner } from "../components/LoadingSpinner";
-import { JobAdEmployer } from "../components/jobAd/JobAdEmployer";
 import { useScreenSize } from "../hooks/useScreenSize";
-import { JobAdDate } from "../components/jobAd/JobAdDate";
+import { JobAdMobileView } from "../components/jobAd/JobAdMobileView";
+import { JobAdDesktopView } from "../components/jobAd/JobAdDesktopView";
 
 export const JobAd = () => {
 	const { id } = useParams<{ id: string }>();
@@ -38,35 +33,5 @@ export const JobAd = () => {
 		return <LoadingSpinner />;
 	}
 
-	return (
-		<DigiTypography>
-			{isMobile ? (
-				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
-					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.ONE}>
-						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
-							<JobAdDetails jobAd={jobAd} />
-							<JobAdDescription jobAd={jobAd} />
-							<JobAdEmployer jobAd={jobAd} />
-							<JobAdApply jobAd={jobAd} />
-							<JobAdDate jobAd={jobAd} />
-						</DigiLayoutBlock>
-					</DigiLayoutColumns>
-				</DigiLayoutBlock>
-			) : (
-				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
-					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.TWO}>
-						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
-							<JobAdDetails jobAd={jobAd} />
-							<JobAdDescription jobAd={jobAd} />
-							<JobAdDate jobAd={jobAd} />
-						</DigiLayoutBlock>
-						<DigiLayoutBlock afVariation={LayoutBlockVariation.SECONDARY} afVerticalPadding={false}>
-							<JobAdEmployer jobAd={jobAd} />
-							<JobAdApply jobAd={jobAd} />
-						</DigiLayoutBlock>
-					</DigiLayoutColumns>
-				</DigiLayoutBlock>
-			)}
-		</DigiTypography>
-	);
+	return <>{isMobile ? <JobAdMobileView jobAd={jobAd} /> : <JobAdDesktopView jobAd={jobAd} />}</>;
 };


### PR DESCRIPTION
Render issues shown when swithing between mobile and desktop and changes inthe DOM.
- Split JobAd component into JobAdMobileView and JobAdDesktopView
- Avoid React "removeChild" error by separating layouts based on screen size with seperate DigiTypography wrapper