### PR TITLE
refactor: use Context for jobAd data instead of passing props

### DIFF
--- a/src/components/jobAd/JobAdApply.tsx
+++ b/src/components/jobAd/JobAdApply.tsx
@@ -6,14 +6,11 @@ import {
 	LayoutContainerVariation,
 } from "@digi/arbetsformedlingen";
 import { DigiInfoCard, DigiLayoutContainer, DigiLinkExternal } from "@digi/arbetsformedlingen-react";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 import { useScreenSize } from "../../hooks/useScreenSize";
+import { useJobAdContext } from "../../contexts/JobAdContext";
 
-type JobAdApplyProps = {
-	jobAd: IJobAdDetailed;
-};
-
-export const JobAdApply = ({ jobAd }: JobAdApplyProps) => {
+export const JobAdApply = () => {
+	const { jobAd } = useJobAdContext();
 	const { isMobile } = useScreenSize();
 
 	return (

--- a/src/components/jobAd/JobAdDate.tsx
+++ b/src/components/jobAd/JobAdDate.tsx
@@ -1,11 +1,9 @@
 import { DigiLayoutContainer, DigiTypographyMeta } from "@digi/arbetsformedlingen-react";
-import type { IJobAdDetailed } from "../../models/IJobAd";
+import { useJobAdContext } from "../../contexts/JobAdContext";
 
-type JobAdDateProps = {
-	jobAd: IJobAdDetailed;
-};
+export const JobAdDate = () => {
+	const { jobAd } = useJobAdContext();
 
-export const JobAdDate = ({ jobAd }: JobAdDateProps) => {
 	return (
 		<DigiLayoutContainer afNoGutter afVerticalPadding={true}>
 			<DigiTypographyMeta afVariation="primary">

--- a/src/components/jobAd/JobAdDescription.tsx
+++ b/src/components/jobAd/JobAdDescription.tsx
@@ -1,12 +1,10 @@
 import { DigiLayoutContainer, DigiTypography } from "@digi/arbetsformedlingen-react";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 import { LayoutContainerVariation } from "@digi/arbetsformedlingen";
+import { useJobAdContext } from "../../contexts/JobAdContext";
 
-type JobAdDescriptionProps = {
-	jobAd: IJobAdDetailed;
-};
+export const JobAdDescription = () => {
+	const { jobAd } = useJobAdContext();
 
-export const JobAdDescription = ({ jobAd }: JobAdDescriptionProps) => {
 	return (
 		<>
 			<DigiTypography>

--- a/src/components/jobAd/JobAdDesktopView.tsx
+++ b/src/components/jobAd/JobAdDesktopView.tsx
@@ -5,26 +5,21 @@ import { JobAdDate } from "./JobAdDate";
 import { JobAdDescription } from "./JobAdDescription";
 import { JobAdDetails } from "./JobAdDetails";
 import { JobAdEmployer } from "./JobAdEmployer";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 
-type JobAdMDesktopViewProps = {
-	jobAd: IJobAdDetailed;
-};
-
-export const JobAdDesktopView = ({ jobAd }: JobAdMDesktopViewProps) => {
+export const JobAdDesktopView = () => {
 	return (
 		<>
 			<DigiTypography style={{ wordBreak: "break-word" }}>
 				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
 					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.TWO}>
 						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
-							<JobAdDetails jobAd={jobAd} />
-							<JobAdDescription jobAd={jobAd} />
-							<JobAdDate jobAd={jobAd} />
+							<JobAdDetails />
+							<JobAdDescription />
+							<JobAdDate />
 						</DigiLayoutBlock>
 						<DigiLayoutBlock afVariation={LayoutBlockVariation.SECONDARY} afVerticalPadding={false}>
-							<JobAdEmployer jobAd={jobAd} />
-							<JobAdApply jobAd={jobAd} />
+							<JobAdEmployer />
+							<JobAdApply />
 						</DigiLayoutBlock>
 					</DigiLayoutColumns>
 				</DigiLayoutBlock>

--- a/src/components/jobAd/JobAdDetails.tsx
+++ b/src/components/jobAd/JobAdDetails.tsx
@@ -1,12 +1,10 @@
 import { DigiLayoutContainer, DigiTypographyMeta } from "@digi/arbetsformedlingen-react";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 import { TypographyMetaVariation } from "@digi/arbetsformedlingen";
+import { useJobAdContext } from "../../contexts/JobAdContext";
 
-type JobAdDetailsProps = {
-	jobAd: IJobAdDetailed;
-};
+export const JobAdDetails = () => {
+	const { jobAd } = useJobAdContext();
 
-export const JobAdDetails = ({ jobAd }: JobAdDetailsProps) => {
 	return (
 		<>
 			<h2>{jobAd.headline}</h2>

--- a/src/components/jobAd/JobAdEmployer.tsx
+++ b/src/components/jobAd/JobAdEmployer.tsx
@@ -1,5 +1,4 @@
 import { DigiInfoCard, DigiLayoutContainer, DigiLinkExternal, DigiMediaImage } from "@digi/arbetsformedlingen-react";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 import {
 	InfoCardBorderPosition,
 	InfoCardHeadingLevel,
@@ -8,12 +7,10 @@ import {
 	LayoutContainerVariation,
 } from "@digi/arbetsformedlingen";
 import { useScreenSize } from "../../hooks/useScreenSize";
+import { useJobAdContext } from "../../contexts/JobAdContext";
 
-type JobAdEmployerProps = {
-	jobAd: IJobAdDetailed;
-};
-
-export const JobAdEmployer = ({ jobAd }: JobAdEmployerProps) => {
+export const JobAdEmployer = () => {
+	const { jobAd } = useJobAdContext();
 	const { isMobile } = useScreenSize();
 
 	return (

--- a/src/components/jobAd/JobAdMobileView.tsx
+++ b/src/components/jobAd/JobAdMobileView.tsx
@@ -5,24 +5,19 @@ import { JobAdDate } from "./JobAdDate";
 import { JobAdDescription } from "./JobAdDescription";
 import { JobAdDetails } from "./JobAdDetails";
 import { JobAdEmployer } from "./JobAdEmployer";
-import type { IJobAdDetailed } from "../../models/IJobAd";
 
-type JobAdMobileViewProps = {
-	jobAd: IJobAdDetailed;
-};
-
-export const JobAdMobileView = ({ jobAd }: JobAdMobileViewProps) => {
+export const JobAdMobileView = () => {
 	return (
 		<>
 			<DigiTypography style={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
 				<DigiLayoutBlock afVariation={LayoutBlockVariation.PRIMARY} afVerticalPadding={true}>
 					<DigiLayoutColumns afElement={LayoutColumnsElement.DIV} afVariation={LayoutColumnsVariation.ONE}>
 						<DigiLayoutBlock afVariation={LayoutBlockVariation.TERTIARY} afVerticalPadding={true}>
-							<JobAdDetails jobAd={jobAd} />
-							<JobAdDescription jobAd={jobAd} />
-							<JobAdEmployer jobAd={jobAd} />
-							<JobAdApply jobAd={jobAd} />
-							<JobAdDate jobAd={jobAd} />
+							<JobAdDetails />
+							<JobAdDescription />
+							<JobAdEmployer />
+							<JobAdApply />
+							<JobAdDate />
 						</DigiLayoutBlock>
 					</DigiLayoutColumns>
 				</DigiLayoutBlock>

--- a/src/contexts/JobAdContext.ts
+++ b/src/contexts/JobAdContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+import type { IJobAdDetailed } from "../models/IJobAd";
+
+type JobAdContextType = {
+	jobAd: IJobAdDetailed;
+};
+
+export const JobAdContext = createContext<JobAdContextType | undefined>(undefined);
+
+export const useJobAdContext = () => {
+	const context = useContext(JobAdContext);
+	if (!context) {
+		throw new Error("useJobAdContext must be used within a JobAdProvider");
+	}
+	return context;
+};

--- a/src/pages/JobAd.tsx
+++ b/src/pages/JobAd.tsx
@@ -6,6 +6,7 @@ import { LoadingSpinner } from "../components/LoadingSpinner";
 import { useScreenSize } from "../hooks/useScreenSize";
 import { JobAdMobileView } from "../components/jobAd/JobAdMobileView";
 import { JobAdDesktopView } from "../components/jobAd/JobAdDesktopView";
+import { JobAdContext } from "../contexts/JobAdContext";
 
 export const JobAd = () => {
 	const { id } = useParams<{ id: string }>();
@@ -33,5 +34,11 @@ export const JobAd = () => {
 		return <LoadingSpinner />;
 	}
 
-	return <>{isMobile ? <JobAdMobileView jobAd={jobAd} /> : <JobAdDesktopView jobAd={jobAd} />}</>;
+	return (
+		<>
+			<JobAdContext.Provider value={{ jobAd }}>
+				{isMobile ? <JobAdMobileView /> : <JobAdDesktopView />}
+			</JobAdContext.Provider>
+		</>
+	);
 };


### PR DESCRIPTION
Use context instead of props to keep code DRY.